### PR TITLE
Add basic integration tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,9 @@
         "phpunit/phpunit": "^9.3",
         "squizlabs/php_codesniffer": "^3.5"
     },
+    "conflict": {
+        "nikic/php-parser": "<v4.12"
+    },
     "scripts": {
         "test": [
             "@phpunit",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,7 +4,7 @@
          bootstrap="vendor/autoload.php"
          executionOrder="depends,defects"
          forceCoversAnnotation="true"
-         beStrictAboutCoversAnnotation="true"
+         beStrictAboutCoversAnnotation="false"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"
          failOnRisky="true"

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -18,7 +18,7 @@ use PDO;
  * @covers Firehed\DbalLogger\SqlLoggerBridge
  * @covers Firehed\DbalLogger\Statement
  */
-class MiddlewareTest extends \PHPUnit\Framework\TestCase
+class IntegrationTest extends \PHPUnit\Framework\TestCase
 {
     public function testConstructWithQueryLogger(): void
     {

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Firehed\DbalLogger;
 
+use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
 use PDO;
 
 /**
@@ -35,9 +37,9 @@ class MiddlewareTest extends \PHPUnit\Framework\TestCase
         $connectionParams = [
             'url' => 'sqlite:///:memory:',
         ];
-        $config = new \Doctrine\DBAL\Configuration();
+        $config = new Configuration();
         $config->setMiddlewares([$middleware]);
-        $conn = \Doctrine\DBAL\DriverManager::getConnection($connectionParams, $config);
+        $conn = DriverManager::getConnection($connectionParams, $config);
 
         $pdo = $conn->getWrappedConnection()->getNativeConnection();
         assert($pdo instanceof PDO);

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Firehed\DbalLogger;
 
+use Doctrine\DBAL\Connection;
+use PDO;
+
 /**
- * @covers Middleware
+ * @covers Firehed\DbalLogger\Middleware
  */
 class MiddlewareTest extends \PHPUnit\Framework\TestCase
 {
@@ -19,18 +22,26 @@ class MiddlewareTest extends \PHPUnit\Framework\TestCase
 
         $c = $this->createDbal($middleware);
         // var_dump($c);
-        $c->query('SELECT 1');
+        // $c->query('SELECT 1');
+
+        $s = $c->prepare('SELECT * FROM users WHERE id = :id');
+        $s->bindValue('id', 'abcdef');
+
+        $r = $s->executeQuery();
     }
 
-    public function createDbal(Middleware $middleware)
+    public function createDbal(Middleware $middleware): Connection
     {
         $connectionParams = [
-            // 'url' => 'mysql://user:secret@localhost/mydb',
             'url' => 'sqlite:///:memory:',
         ];
         $config = new \Doctrine\DBAL\Configuration();
         $config->setMiddlewares([$middleware]);
         $conn = \Doctrine\DBAL\DriverManager::getConnection($connectionParams, $config);
+
+        $pdo = $conn->getWrappedConnection()->getNativeConnection();
+        assert($pdo instanceof PDO);
+        $pdo->exec('CREATE TABLE users (id string PRIMARY KEY);');
 
         return $conn;
     }

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\DbalLogger;
+
+/**
+ * @covers Middleware
+ */
+class MiddlewareTest extends \PHPUnit\Framework\TestCase
+{
+    public function testConstruct(): void
+    {
+        $logger = self::createMock(QueryLogger::class);
+        $logger->expects(self::once())
+            ->method('startQuery')
+            ->willReturnCallback(var_dump(...));
+        $middleware = new Middleware($logger);
+
+        $c = $this->createDbal($middleware);
+        // var_dump($c);
+        $c->query('SELECT 1');
+    }
+
+    public function createDbal(Middleware $middleware)
+    {
+        $connectionParams = [
+            // 'url' => 'mysql://user:secret@localhost/mydb',
+            'url' => 'sqlite:///:memory:',
+        ];
+        $config = new \Doctrine\DBAL\Configuration();
+        $config->setMiddlewares([$middleware]);
+        $conn = \Doctrine\DBAL\DriverManager::getConnection($connectionParams, $config);
+
+        return $conn;
+    }
+}

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -10,7 +10,13 @@ use Doctrine\DBAL\DriverManager;
 use PDO;
 
 /**
+ * @group integration
+ *
+ * @covers Firehed\DbalLogger\Connection
+ * @covers Firehed\DbalLogger\Driver
  * @covers Firehed\DbalLogger\Middleware
+ * @covers Firehed\DbalLogger\SqlLoggerBridge
+ * @covers Firehed\DbalLogger\Statement
  */
 class MiddlewareTest extends \PHPUnit\Framework\TestCase
 {


### PR DESCRIPTION
Adds basic integration tests which validate that the hook methods are called when used as part of a DBAL config middleware entry.