### PR TITLE
Get tests off of deprecated methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         "maglnet/composer-require-checker": "^2.0 || ^3.0 || ^4.0",
         "mheap/phpunit-github-actions-printer": "^1.5",
         "phpstan/phpstan": "^1.0",
+        "phpstan/phpstan-deprecation-rules": "^1.1",
         "phpstan/phpstan-phpunit": "^1.0",
         "phpstan/phpstan-strict-rules": "^1.0",
         "phpunit/phpunit": "^9.3",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,6 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Call to deprecated method withConsecutive\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\Builder\\\\InvocationMocker\\.$#"
+			count: 2
+			path: tests/IntegrationTest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,14 @@
 parameters:
 	ignoreErrors:
 		-
+			message: """
+				#^Call to deprecated method bindParam\\(\\) of class Doctrine\\\\DBAL\\\\Statement\\:
+				Use \\{@see bindValue\\(\\)\\} instead\\.$#
+			"""
+			count: 1
+			path: tests/IntegrationTest.php
+
+		-
 			message: "#^Call to deprecated method withConsecutive\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\Builder\\\\InvocationMocker\\.$#"
 			count: 2
 			path: tests/IntegrationTest.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 includes:
-    # phpstan-baseline.neon
+    - phpstan-baseline.neon
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/phpstan/phpstan-deprecation-rules/rules.neon
     - vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,7 @@
 includes:
     # phpstan-baseline.neon
     - vendor/phpstan/phpstan-phpunit/extension.neon
+    - vendor/phpstan/phpstan-deprecation-rules/rules.neon
     - vendor/phpstan/phpstan-strict-rules/rules.neon
 parameters:
     ignoreErrors:

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -126,12 +126,12 @@ class IntegrationTest extends \PHPUnit\Framework\TestCase
     public function testExecAndQuery(QueryLogger $logger): void
     {
         $conn = $this->createDbal($logger);
-        $rowCount = $conn->exec("INSERT INTO users (id) VALUES ('a')");
-        $rowCount = $conn->exec("INSERT INTO users (id) VALUES ('b')");
-        $rowCount = $conn->exec("INSERT INTO users (id) VALUES ('c')");
+        $rowCount = $conn->executeStatement("INSERT INTO users (id) VALUES ('a')");
+        $rowCount = $conn->executeStatement("INSERT INTO users (id) VALUES ('b')");
+        $rowCount = $conn->executeStatement("INSERT INTO users (id) VALUES ('c')");
         self::assertSame(1, $rowCount);
 
-        $rows = $conn->query('SELECT * FROM users')->fetchAllAssociative();
+        $rows = $conn->executeQuery('SELECT * FROM users')->fetchAllAssociative();
         self::assertCount(3, $rows);
     }
 

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -68,7 +68,7 @@ class IntegrationTest extends \PHPUnit\Framework\TestCase
     public function testBindValueByPosition(QueryLogger $logger): void
     {
         $conn = $this->createDbal($logger);
-        $conn->exec("INSERT INTO users (id) VALUES ('a')");
+        $this->insertRow($conn, 'a');
 
         $logger->expects(self::once())
             ->method('startQuery')
@@ -87,7 +87,7 @@ class IntegrationTest extends \PHPUnit\Framework\TestCase
     public function testBindValueByName(QueryLogger $logger): void
     {
         $conn = $this->createDbal($logger);
-        $conn->exec("INSERT INTO users (id) VALUES ('a')");
+        $this->insertRow($conn, 'a');
 
         $logger->expects(self::once())
             ->method('startQuery')
@@ -106,7 +106,7 @@ class IntegrationTest extends \PHPUnit\Framework\TestCase
     public function testBindParamByName(QueryLogger $logger): void
     {
         $conn = $this->createDbal($logger);
-        $conn->exec("INSERT INTO users (id) VALUES ('a')");
+        $this->insertRow($conn, 'a');
 
         $logger->expects(self::once())
             ->method('startQuery')
@@ -202,5 +202,10 @@ class IntegrationTest extends \PHPUnit\Framework\TestCase
         $pdo->exec('CREATE TABLE users (id string PRIMARY KEY);');
 
         return $conn;
+    }
+
+    private function insertRow(Connection $conn, string $id): void
+    {
+        $conn->executeStatement("INSERT INTO users (id) VALUES (:id)", ['id' => $id]);
     }
 }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -114,7 +114,7 @@ class IntegrationTest extends \PHPUnit\Framework\TestCase
 
         $stmt = $conn->prepare('SELECT * FROM users WHERE id = :id');
         $id = 'a';
-        $stmt->bindValue('id', $id);
+        $stmt->bindParam('id', $id);
         $results = $stmt->executeQuery();
         self::assertCount(1, $results->fetchAllAssociative());
     }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -34,7 +34,7 @@ class IntegrationTest extends \PHPUnit\Framework\TestCase
         $logger->expects(self::once())
             ->method('stopQuery');
 
-        $conn->query('SELECT 1');
+        $conn->executeQuery('SELECT 1');
 
         $conn->close();
     }
@@ -53,7 +53,7 @@ class IntegrationTest extends \PHPUnit\Framework\TestCase
         $logger->expects(self::once())
             ->method('stopQuery');
 
-        $conn->query('SELECT 1');
+        $conn->executeQuery('SELECT 1');
 
         $logger->expects(self::once())
             ->method('disconnect');
@@ -114,7 +114,7 @@ class IntegrationTest extends \PHPUnit\Framework\TestCase
 
         $stmt = $conn->prepare('SELECT * FROM users WHERE id = :id');
         $id = 'a';
-        $stmt->bindParam('id', $id);
+        $stmt->bindValue('id', $id);
         $results = $stmt->executeQuery();
         self::assertCount(1, $results->fetchAllAssociative());
     }
@@ -197,7 +197,7 @@ class IntegrationTest extends \PHPUnit\Framework\TestCase
         $config->setMiddlewares([new Middleware($logger)]);
         $conn = DriverManager::getConnection($connectionParams, $config);
 
-        $pdo = $conn->getWrappedConnection()->getNativeConnection();
+        $pdo = $conn->getNativeConnection();
         assert($pdo instanceof PDO);
         $pdo->exec('CREATE TABLE users (id string PRIMARY KEY);');
 


### PR DESCRIPTION
This will ease the future support of DBAL4 which will remove these methods.