### PR TITLE
Add native return types where possible

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -59,10 +59,7 @@ final class Connection extends AbstractConnectionMiddleware
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function beginTransaction()
+    public function beginTransaction(): bool
     {
         $this->logger->startQuery('START TRANSACTION');
         try {
@@ -72,10 +69,7 @@ final class Connection extends AbstractConnectionMiddleware
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function commit()
+    public function commit(): bool
     {
         $this->logger->startQuery('COMMIT');
         try {
@@ -85,10 +79,7 @@ final class Connection extends AbstractConnectionMiddleware
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function rollBack()
+    public function rollBack(): bool
     {
         $this->logger->startQuery('ROLLBACK');
         try {

--- a/src/Driver.php
+++ b/src/Driver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\DbalLogger;
 
 use Doctrine\DBAL\Driver as DriverInterface;
+use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
 use Psr\Log\LoggerInterface;
 
@@ -26,7 +27,7 @@ final class Driver extends AbstractDriverMiddleware
     /**
      * {@inheritDoc}
      */
-    public function connect(array $params)
+    public function connect(array $params): DriverConnection
     {
         $this->logger->connect();
 

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -43,7 +43,7 @@ final class Statement extends AbstractStatementMiddleware
      *
      * @deprecated Use {@see bindValue()} instead.
      */
-    public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null)
+    public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null): bool
     {
         Deprecation::trigger(
             'doctrine/dbal',
@@ -70,7 +70,7 @@ final class Statement extends AbstractStatementMiddleware
     /**
      * {@inheritdoc}
      */
-    public function bindValue($param, $value, $type = ParameterType::STRING)
+    public function bindValue($param, $value, $type = ParameterType::STRING): bool
     {
         if (func_num_args() < 3) {
             Deprecation::trigger(


### PR DESCRIPTION
In addition to clarity, this will ease the adoption of Dbal4 and really highlight where BC breaks exist.