### PR TITLE
Support DBAL 4; drop DBAL 3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,10 @@ jobs:
           - 'high'
           - 'low'
         php:
-          - '7.4'
-          - '8.0'
           - '8.1'
           - '8.2'
+          - '8.3'
+          - '8.4-dev'
 
     steps:
       - name: Check out code

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,12 @@
+# 2.0.0
+
+This adds support for DBAL 4, and drops support for DBAL 3.
+
+While the internal APIs have some significant changes to account for this, the user-facing API is _mostly_ unchanged.
+There is one probably-small adjustment to account for:
+
+`QueryLogger::startQuery()`'s third parameter, `$types` now takes an array of `\Doctrine\DBAL\ParameterType` enums instead of the previous `int` values.
+If your logger does not look at `$types`, you almost certainly don't have to do anything.
+
+Since the enum-based version in DBAL 4 is name-compatible with the constants in DBAL 3 (e.g. `ParameterType::STRING`), it's possible you don't need to make any changes to your implementation.
+Depending on _what_ you're using the `$types` for, you may need to adjust your output format.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -9,4 +9,4 @@ There is one probably-small adjustment to account for:
 If your logger does not look at `$types`, you almost certainly don't have to do anything.
 
 Since the enum-based version in DBAL 4 is name-compatible with the constants in DBAL 3 (e.g. `ParameterType::STRING`), it's possible you don't need to make any changes to your implementation.
-Depending on _what_ you're using the `$types` for, you may need to adjust your output format.
+Depending on _how_ you're using `$types`, you may need to adjust your implementation or output format.

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         }
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "doctrine/dbal": "^4.0",
         "doctrine/deprecations": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "require": {
         "php": "^7.4 || ^8.0",
-        "doctrine/dbal": "^3.3 || ^4.0",
+        "doctrine/dbal": "^4.0",
         "doctrine/deprecations": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "require": {
         "php": "^7.4 || ^8.0",
-        "doctrine/dbal": "^3.3",
+        "doctrine/dbal": "^3.3 || ^4.0",
         "doctrine/deprecations": "^1.0"
     },
     "require-dev": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,14 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: """
-				#^Call to deprecated method bindParam\\(\\) of class Doctrine\\\\DBAL\\\\Statement\\:
-				Use \\{@see bindValue\\(\\)\\} instead\\.$#
-			"""
-			count: 1
-			path: tests/IntegrationTest.php
-
-		-
 			message: "#^Call to deprecated method withConsecutive\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\Builder\\\\InvocationMocker\\.$#"
 			count: 2
 			path: tests/IntegrationTest.php

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -49,7 +49,7 @@ final class Connection extends AbstractConnectionMiddleware
         }
     }
 
-    public function exec(string $sql): int
+    public function exec(string $sql): int|string
     {
         $this->logger->startQuery($sql);
         try {
@@ -59,40 +59,31 @@ final class Connection extends AbstractConnectionMiddleware
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function beginTransaction()
+    public function beginTransaction(): void
     {
         $this->logger->startQuery('START TRANSACTION');
         try {
-            return parent::beginTransaction();
+            parent::beginTransaction();
         } finally {
             $this->logger->stopQuery();
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function commit()
+    public function commit(): void
     {
         $this->logger->startQuery('COMMIT');
         try {
-            return parent::commit();
+            parent::commit();
         } finally {
             $this->logger->stopQuery();
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function rollBack()
+    public function rollBack(): void
     {
         $this->logger->startQuery('ROLLBACK');
         try {
-            return parent::rollBack();
+            parent::rollBack();
         } finally {
             $this->logger->stopQuery();
         }

--- a/src/Driver.php
+++ b/src/Driver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\DbalLogger;
 
 use Doctrine\DBAL\Driver as DriverInterface;
+use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
 use Psr\Log\LoggerInterface;
 
@@ -26,7 +27,7 @@ final class Driver extends AbstractDriverMiddleware
     /**
      * {@inheritDoc}
      */
-    public function connect(array $params)
+    public function connect(array $params): DriverConnection
     {
         $this->logger->connect();
 

--- a/src/QueryLogger.php
+++ b/src/QueryLogger.php
@@ -19,7 +19,7 @@ interface QueryLogger
      *
      * @return void
      */
-    public function startQuery($sql, array $params = null, array $types = []);
+    public function startQuery($sql, ?array $params = null, ?array $types = null);
 
     /**
      * Marks the last started query as stopped. This can be used for timing of queries.

--- a/src/QueryLogger.php
+++ b/src/QueryLogger.php
@@ -2,6 +2,7 @@
 
 namespace Firehed\DbalLogger;
 
+use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Types\Type;
 
 /**
@@ -14,11 +15,11 @@ interface QueryLogger
      *
      * @param string                                                                    $sql    SQL statement
      * @param list<mixed>|array<string, mixed>|null                                     $params Statement parameters
-     * @param array<int, Type|int|string|null>|array<string, Type|int|string|null>|null $types  Parameter types
+     * @param ParameterType[] $types
      *
      * @return void
      */
-    public function startQuery($sql, ?array $params = null, ?array $types = null);
+    public function startQuery($sql, array $params = null, array $types = []);
 
     /**
      * Marks the last started query as stopped. This can be used for timing of queries.

--- a/src/QueryLogger.php
+++ b/src/QueryLogger.php
@@ -13,8 +13,8 @@ interface QueryLogger
     /**
      * Logs a SQL statement somewhere.
      *
-     * @param string                                                                    $sql    SQL statement
-     * @param list<mixed>|array<string, mixed>|null                                     $params Statement parameters
+     * @param string $sql SQL statement
+     * @param list<mixed>|array<string, mixed>|null $params Statement parameters
      * @param ParameterType[] $types
      *
      * @return void

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -23,10 +23,10 @@ final class Statement extends AbstractStatementMiddleware
     private DbalLogger $logger;
     private string $sql;
 
-    /** @var array<int,mixed>|array<string,mixed> */
+    /** @var mixed[] */
     private array $params = [];
 
-    /** @var array<ParameterType> */
+    /** @var ParameterType[] */
     private array $types = [];
 
     /** @internal This statement can be only instantiated by its connection. */

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -26,7 +26,7 @@ final class Statement extends AbstractStatementMiddleware
     /** @var array<int,mixed>|array<string,mixed> */
     private array $params = [];
 
-    /** @var array<int,int>|array<string,int> */
+    /** @var array<ParameterType> */
     private array $types = [];
 
     /** @internal This statement can be only instantiated by its connection. */
@@ -38,63 +38,19 @@ final class Statement extends AbstractStatementMiddleware
         $this->sql    = $sql;
     }
 
-    /**
-     * {@inheritdoc}
-     *
-     * @deprecated Use {@see bindValue()} instead.
-     */
-    public function bindParam($param, &$variable, $type = ParameterType::STRING, $length = null)
+    public function bindValue(int|string $param, mixed $value, ParameterType $type): void
     {
-        Deprecation::trigger(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5563',
-            '%s is deprecated. Use bindValue() instead.',
-            __METHOD__,
-        );
-
-        if (func_num_args() < 3) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/5558',
-                'Not passing $type to Statement::bindParam() is deprecated.'
-                    . ' Pass the type corresponding to the parameter being bound.',
-            );
-        }
-
-        $this->params[$param] = &$variable;
-        $this->types[$param]  = $type;
-
-        return parent::bindParam($param, $variable, $type, $length);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function bindValue($param, $value, $type = ParameterType::STRING)
-    {
-        if (func_num_args() < 3) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/5558',
-                'Not passing $type to Statement::bindValue() is deprecated.'
-                    . ' Pass the type corresponding to the parameter being bound.',
-            );
-        }
-
         $this->params[$param] = $value;
         $this->types[$param]  = $type;
 
-        return parent::bindValue($param, $value, $type);
+        parent::bindValue($param, $value, $type);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function execute($params = null): ResultInterface
+    public function execute(): ResultInterface
     {
-        $this->logger->startQuery($this->sql, $params ?? $this->params, $this->types);
+        $this->logger->startQuery($this->sql, $this->params, $this->types);
         try {
-            return parent::execute($params);
+            return parent::execute();
         } finally {
             $this->logger->stopQuery();
         }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -103,26 +103,6 @@ class IntegrationTest extends \PHPUnit\Framework\TestCase
      * @dataProvider loggers
      * @param MockObject&QueryLogger $logger
      */
-    public function testBindParamByName(QueryLogger $logger): void
-    {
-        $conn = $this->createDbal($logger);
-        $this->insertRow($conn, 'a');
-
-        $logger->expects(self::once())
-            ->method('startQuery')
-            ->with('SELECT * FROM users WHERE id = :id', ['id' => 'a'], ['id' => ParameterType::STRING]);
-
-        $stmt = $conn->prepare('SELECT * FROM users WHERE id = :id');
-        $id = 'a';
-        $stmt->bindParam('id', $id);
-        $results = $stmt->executeQuery();
-        self::assertCount(1, $results->fetchAllAssociative());
-    }
-
-    /**
-     * @dataProvider loggers
-     * @param MockObject&QueryLogger $logger
-     */
     public function testExecAndQuery(QueryLogger $logger): void
     {
         $conn = $this->createDbal($logger);

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -7,6 +7,7 @@ namespace Firehed\DbalLogger;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\ParameterType;
 use PDO;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -144,7 +145,7 @@ class IntegrationTest extends \PHPUnit\Framework\TestCase
             ->method('startQuery')
             ->withConsecutive(
                 ['START TRANSACTION', null, null],
-                ['INSERT INTO users (id) VALUES (:id)', ['id' => 'abc'], ['id' => 2]],
+                ['INSERT INTO users (id) VALUES (:id)', ['id' => 'abc'], ['id' => ParameterType::STRING]],
                 ['COMMIT', null, null],
             );
         $conn = $this->createDbal($logger);
@@ -165,7 +166,7 @@ class IntegrationTest extends \PHPUnit\Framework\TestCase
             ->method('startQuery')
             ->withConsecutive(
                 ['START TRANSACTION', null, null],
-                ['INSERT INTO users (id) VALUES (:id)', ['id' => 'abc'], ['id' => 2]],
+                ['INSERT INTO users (id) VALUES (:id)', ['id' => 'abc'], ['id' => ParameterType::STRING]],
                 ['ROLLBACK', null, null],
             );
         $conn = $this->createDbal($logger);

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -148,11 +148,11 @@ class IntegrationTest extends \PHPUnit\Framework\TestCase
                 ['COMMIT', null, null],
             );
         $conn = $this->createDbal($logger);
-        self::assertTrue($conn->beginTransaction());
+        $conn->beginTransaction();
         $stmt = $conn->prepare('INSERT INTO users (id) VALUES (:id)');
         $stmt->bindValue('id', 'abc');
         self::assertSame(1, $stmt->executeStatement());
-        self::assertTrue($conn->commit());
+        $conn->commit();
     }
 
     /**
@@ -169,11 +169,11 @@ class IntegrationTest extends \PHPUnit\Framework\TestCase
                 ['ROLLBACK', null, null],
             );
         $conn = $this->createDbal($logger);
-        self::assertTrue($conn->beginTransaction());
+        $conn->beginTransaction();
         $stmt = $conn->prepare('INSERT INTO users (id) VALUES (:id)');
         $stmt->bindValue('id', 'abc');
         self::assertSame(1, $stmt->executeStatement());
-        self::assertTrue($conn->rollBack());
+        $conn->rollBack();
     }
 
     /**

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -191,12 +191,13 @@ class IntegrationTest extends \PHPUnit\Framework\TestCase
     {
         $connectionParams = [
             'url' => 'sqlite:///:memory:',
+            'driver' => 'pdo_sqlite',
         ];
         $config = new Configuration();
         $config->setMiddlewares([new Middleware($logger)]);
         $conn = DriverManager::getConnection($connectionParams, $config);
 
-        $pdo = $conn->getWrappedConnection()->getNativeConnection();
+        $pdo = $conn->getNativeConnection();
         assert($pdo instanceof PDO);
         $pdo->exec('CREATE TABLE users (id string PRIMARY KEY);');
 


### PR DESCRIPTION
There doesn't seem to be any reasonable way to support both.

While the _literal_ type signatures don't change for any public API code, that's only due to the fact that there's no native typed arrays in PHP. Consequently, this is a BC break. I've added an UPGRADING document to indicate how to handle this (testing this in a real application, I needed no change since I wasn't logging or otherwise using the affected parameter)