### PR TITLE
Remove dependency on doctrine/deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,7 @@
     },
     "require": {
         "php": "^8.1",
-        "doctrine/dbal": "^4.0",
-        "doctrine/deprecations": "^1.0"
+        "doctrine/dbal": "^4.0"
     },
     "require-dev": {
         "maglnet/composer-require-checker": "^2.0 || ^3.0 || ^4.0",

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware;
 use Doctrine\DBAL\Driver\Result as ResultInterface;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
 use Doctrine\DBAL\ParameterType;
-use Doctrine\Deprecations\Deprecation;
 use Psr\Log\LoggerInterface;
 
 use function array_slice;


### PR DESCRIPTION
This existed only to mirror previous behavior. It's no longer relevant.