### PR TITLE
Add chain logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ If you _don't_ have a SQLLogger implementation you're looking to migrate, you'll
 
 That should do it!
 
+## I need to log to multiple backends!
+
+No problem - there's a built in `ChainLogger` that accepts an array of `QueryLogger`/`DbalLogger` instances.
+When configured, it will relay all of the logging events it receives to each of the loggers.
+
+```php
+$logger1 = new MyLogger();
+$logger2 = new MyOtherLogger(); // Maybe metrics?
+$chain = new ChainLogger([$logger1, $logger2]);
+$config->setMiddlewares([new LoggerMiddleware($chain)])
+```
+
 ## Misc
 
 This project follows semantic versioning.

--- a/src/ChainLogger.php
+++ b/src/ChainLogger.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\DbalLogger;
+
+/**
+ * Runs all of the specified loggers, FIFO.
+ */
+class ChainLogger implements DbalLogger
+{
+    /**
+     * @param QueryLogger[] $loggers
+     */
+    public function __construct(private array $loggers)
+    {
+    }
+
+    public function connect(): void
+    {
+        foreach ($this->loggers as $logger) {
+            if ($logger instanceof DbalLogger) {
+                $logger->connect();
+            }
+        }
+    }
+
+    public function disconnect(): void
+    {
+        foreach ($this->loggers as $logger) {
+            if ($logger instanceof DbalLogger) {
+                $logger->disconnect();
+            }
+        }
+    }
+
+    public function startQuery($sql, ?array $params = null, ?array $types = null): void
+    {
+        foreach ($this->loggers as $logger) {
+            $logger->startQuery($sql, $params, $types);
+        }
+    }
+
+    public function stopQuery(): void
+    {
+        foreach ($this->loggers as $logger) {
+            $logger->stopQuery();
+        }
+    }
+}

--- a/tests/ChainLoggerTest.php
+++ b/tests/ChainLoggerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\DbalLogger;
+
+use Doctrine\DBAL\ParameterType;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Firehed\DbalLogger\ChainLogger
+ */
+class ChainLoggerTest extends TestCase
+{
+    private DbalLogger&MockObject $l1;
+    private DbalLogger&MockObject $l2;
+    private ChainLogger $logger;
+
+    public function setUp(): void
+    {
+        $this->l1 = self::createMock(DbalLogger::class);
+        $this->l2 = self::createMock(DbalLogger::class);
+        $this->logger = new ChainLogger([$this->l1, $this->l2]);
+    }
+
+    public function testConnectDelegates(): void
+    {
+        $this->l1->expects(self::once())->method('connect');
+        $this->l2->expects(self::once())->method('connect');
+        $this->logger->connect();
+    }
+
+    public function testDisconnectDelegates(): void
+    {
+        $this->l1->expects(self::once())->method('disconnect');
+        $this->l2->expects(self::once())->method('disconnect');
+        $this->logger->disconnect();
+    }
+
+    public function testStartQueryDelegates(): void
+    {
+        $sql = 'SELECT * FROM foos WHERE id = ? AND bar IN (?, ?)';
+        $params = [1, 'a', 'b'];
+        $types = [ParameterType::INTEGER, ParameterType::STRING, ParameterType::STRING];
+        $this->l1->expects(self::once())->method('startQuery')->with($sql, $params, $types);
+        $this->l2->expects(self::once())->method('startQuery')->with($sql, $params, $types);
+        $this->logger->startQuery($sql, $params, $types);
+    }
+
+    public function testStopQueryDelegates(): void
+    {
+        $this->l1->expects(self::once())->method('stopQuery');
+        $this->l2->expects(self::once())->method('stopQuery');
+        $this->logger->stopQuery();
+    }
+}

--- a/tests/ChainLoggerTest.php
+++ b/tests/ChainLoggerTest.php
@@ -15,19 +15,22 @@ class ChainLoggerTest extends TestCase
 {
     private DbalLogger&MockObject $l1;
     private DbalLogger&MockObject $l2;
+    private QueryLogger&MockObject $l3;
     private ChainLogger $logger;
 
     public function setUp(): void
     {
         $this->l1 = self::createMock(DbalLogger::class);
         $this->l2 = self::createMock(DbalLogger::class);
-        $this->logger = new ChainLogger([$this->l1, $this->l2]);
+        $this->l3 = self::createMock(QueryLogger::class);
+        $this->logger = new ChainLogger([$this->l1, $this->l2, $this->l3]);
     }
 
     public function testConnectDelegates(): void
     {
         $this->l1->expects(self::once())->method('connect');
         $this->l2->expects(self::once())->method('connect');
+        // No l3
         $this->logger->connect();
     }
 
@@ -35,6 +38,7 @@ class ChainLoggerTest extends TestCase
     {
         $this->l1->expects(self::once())->method('disconnect');
         $this->l2->expects(self::once())->method('disconnect');
+        // No l3
         $this->logger->disconnect();
     }
 
@@ -45,6 +49,7 @@ class ChainLoggerTest extends TestCase
         $types = [ParameterType::INTEGER, ParameterType::STRING, ParameterType::STRING];
         $this->l1->expects(self::once())->method('startQuery')->with($sql, $params, $types);
         $this->l2->expects(self::once())->method('startQuery')->with($sql, $params, $types);
+        $this->l3->expects(self::once())->method('startQuery')->with($sql, $params, $types);
         $this->logger->startQuery($sql, $params, $types);
     }
 
@@ -52,6 +57,7 @@ class ChainLoggerTest extends TestCase
     {
         $this->l1->expects(self::once())->method('stopQuery');
         $this->l2->expects(self::once())->method('stopQuery');
+        $this->l3->expects(self::once())->method('stopQuery');
         $this->logger->stopQuery();
     }
 }


### PR DESCRIPTION
Adds a `ChainLogger` class, which accepts multiple logger instances and relays all of the log events to all of them. This is useful when you need multiple logging-type backends - for instance, a traditional (e.g. psr/log) logger and a metrics collector.

Contributed by @snapauthapp!